### PR TITLE
Pantalla de muerte y respawn

### DIFF
--- a/TaiFighter/assets/scripts/Client/Events/PlayerDeathEv.lua
+++ b/TaiFighter/assets/scripts/Client/Events/PlayerDeathEv.lua
@@ -1,0 +1,7 @@
+local ns = require("namespace")
+
+ns.PlayerDeathEv = ns.class("PlayerDeathEv")
+
+function ns.PerspectiveChangeEnd:initialize()
+	LOG("Firing PlayerDeathEv")
+end

--- a/TaiFighter/assets/scripts/Client/EventsList.lua
+++ b/TaiFighter/assets/scripts/Client/EventsList.lua
@@ -3,3 +3,4 @@
 require('ChangePerspectiveEvent')
 require('PerspectiveChangeEnd')
 require('Add3DTimeEvent')
+require('PlayerDeathEv')

--- a/TaiFighter/assets/scripts/Client/Prefabs/Player.lua
+++ b/TaiFighter/assets/scripts/Client/Prefabs/Player.lua
@@ -15,7 +15,7 @@ function pf.Player(params)
 			-- Example user defined components
 			{ name = "playerMove", arguments = { 1, 1, 1 }}, 
 			{ name = "boombox", arguments={0.5,false,require('resources').Sounds.LevelTheme,-1}},
-			{ name = "health", arguments = { 1, false}},
+			{ name = "health", arguments = { 3, false}},
 			{ name = "variableCollider", arguments = {}}
 			-- { name = "playerMove", arguments = { { x = 1, y = 0, z = 0 } } }
 		},

--- a/TaiFighter/assets/scripts/Client/Prefabs/Player.lua
+++ b/TaiFighter/assets/scripts/Client/Prefabs/Player.lua
@@ -15,7 +15,7 @@ function pf.Player(params)
 			-- Example user defined components
 			{ name = "playerMove", arguments = { 1, 1, 1 }}, 
 			{ name = "boombox", arguments={0.5,false,require('resources').Sounds.LevelTheme,-1}},
-			{ name = "health", arguments = { 3, false}},
+			{ name = "health", arguments = { 1, false}},
 			{ name = "variableCollider", arguments = {}}
 			-- { name = "playerMove", arguments = { { x = 1, y = 0, z = 0 } } }
 		},

--- a/TaiFighter/assets/scripts/Client/Systems/HealthSystem.lua
+++ b/TaiFighter/assets/scripts/Client/Systems/HealthSystem.lua
@@ -6,11 +6,21 @@ local HealthSystem = ns.class("HealthSystem",ns.System)
 
 function HealthSystem:requires() return {"health"} end
 
+function HealthSystem:restockLives()
+	for _, entity in pairs(self.targets) do
+		local health = entity:get("health")
+		health.lives = health.maxLives
+	end
+end
+
 function HealthSystem:onCollision(player, other, _)
 	if(player:get("health").invulnerabilityTime == 0 and other:has("damagePlayer")) then
 		local health = player:get("health")
 		health.lives = health.lives -1
-		if(health.lives == 0) then LOG("Player DEAD")
+		if(health.lives == 0) then
+			 LOG("Player DEAD")
+			 showDeathUI()
+			 Manager.eventManager:fireEvent(ns.PlayerDeathEv())
 		else 
 			LOG("Current lives: " .. health.lives)
 			health.invulnerabilityTime = 60
@@ -48,6 +58,7 @@ function HealthSystem:initialize()
 	ns.System.initialize(self)
 	self.timer = 0 -- for invulnerability
 	self.player = nil
+	Manager.eventManager:addListener("ChangeSceneEvent", self, self.restockLives)
 end
 
 Manager:addSystem(HealthSystem())

--- a/TaiFighter/assets/scripts/Client/Systems/HealthSystem.lua
+++ b/TaiFighter/assets/scripts/Client/Systems/HealthSystem.lua
@@ -14,12 +14,14 @@ function HealthSystem:restockLives()
 end
 
 function HealthSystem:onCollision(player, other, _)
+	if not self.isActive then return end
 	if(player:get("health").invulnerabilityTime == 0 and other:has("damagePlayer")) then
 		local health = player:get("health")
 		health.lives = health.lives -1
 		if(health.lives == 0) then
 			 LOG("Player DEAD")
 			 showDeathUI()
+			 self.isActive = false
 			 Manager.eventManager:fireEvent(ns.PlayerDeathEv())
 		else 
 			LOG("Current lives: " .. health.lives)
@@ -34,6 +36,7 @@ function HealthSystem:onCollision(player, other, _)
 end
 
 function HealthSystem:update(dt)
+	if not self.isActive then return end
 	for _, entity in pairs(self.targets) do
 		local health = entity:get("health")
 		if(health.invulnerabilityTime > 0) then
@@ -54,11 +57,17 @@ function HealthSystem:onAddEntity(entity)
 	self.player = entity
 end
 
+function HealthSystem:activateSys()
+	self.isActive = true
+end
+
 function HealthSystem:initialize()
 	ns.System.initialize(self)
 	self.timer = 0 -- for invulnerability
 	self.player = nil
+	self.isActive = true
 	Manager.eventManager:addListener("ChangeSceneEvent", self, self.restockLives)
+	Manager.eventManager:addListener("ChangeSceneEvent", self, self.activateSys)
 end
 
 Manager:addSystem(HealthSystem())

--- a/TaiFighter/assets/scripts/Client/Systems/MoveSystem.lua
+++ b/TaiFighter/assets/scripts/Client/Systems/MoveSystem.lua
@@ -19,10 +19,22 @@ MoveSystem.dirs = {
 	backward = vec3:new(-1, 0, 0)
 }
 
+function MoveSystem:stopMove()
+	self.canMove = false
+end
+
+function MoveSystem:restartMovement()
+	self.canMove = true
+end
+
 function MoveSystem:initialize()
 	ns.System.initialize(self)
+	self.canMove = true
 	--Setting a listener for when the 3Dbar is depleated (Fires the change of perspective)
 	Manager.eventManager:addListener("PerspectiveChangeEnd", self, self.Change)
+	Manager.eventManager:addListener("PlayerDeathEv", self, self.stopMove)
+	Manager.eventManager:addListener("ChangeSceneEvent", self, self.restartMovement)
+
 end
 
 function MoveSystem:requires() return { "playerMove" } end
@@ -113,6 +125,7 @@ function MoveSystem:ControllerHandleInput(entity,dt,speed)
 end
 
 function MoveSystem:update(dt)
+	if not self.canMove then return end
 	for _, entity in pairs(self.targets) do
 		local playerMoveCom = entity:get("playerMove")
 		local vx = playerMoveCom.x

--- a/TaiFighter/assets/scripts/Client/Systems/ScrollMovementSystem.lua
+++ b/TaiFighter/assets/scripts/Client/Systems/ScrollMovementSystem.lua
@@ -2,14 +2,30 @@ local ns = require('namespace')
 
 local ScrollMovementSystem = ns.class("ScrollMovementSystem",ns.System)
 
+function ScrollMovementSystem:forceStop()
+	self.scrolling = false
+end
+
+function ScrollMovementSystem:restartMovement()
+	self.scrolling = true
+end
+
 function ScrollMovementSystem:requires() return {"scrollMovement"} end
 
 function ScrollMovementSystem:update(dt)
+	if not self.scrolling then return end
 	for _, entity in pairs(self.targets) do
 		local moveSpeed = entity:get("scrollMovement").speed
 		local movement = vec3:new(-moveSpeed*dt,0,0)
 		entity.Transform:translate(movement)
 	end
+end
+
+function ScrollMovementSystem:initialize()
+	ns.System.initialize(self)
+	self.scrolling = true
+	Manager.eventManager:addListener("PlayerDeathEv", self, self.forceStop)
+	Manager.eventManager:addListener("ChangeSceneEvent", self, self.restartMovement)
 end
 
 Manager:addSystem(ScrollMovementSystem())

--- a/TaiFighter/assets/scripts/Client/UIcallbacks.lua
+++ b/TaiFighter/assets/scripts/Client/UIcallbacks.lua
@@ -1,3 +1,23 @@
+function createDeathUI()
+	createButton("RetryButton", "Retry", "TaharezLook/Button","DejaVuSans-12",vec2:new(.45, .5), vec2:new(.1, .05))
+	setButtonFunction("RetryButton","RetryCallback")
+
+	createButton("ReturnMenuButton","Return to menu", "TaharezLook/Button","DejaVuSans-12",vec2:new(.45, .7), vec2:new(.1, .05))
+	setButtonFunction("ReturnMenuButton","ReturnMenuCallback")
+
+	hideDeathUI()
+end
+
+function showDeathUI()
+	setWindowVisible("ReturnMenuButton", true)
+	setWindowVisible("RetryButton", true)
+end
+
+function hideDeathUI()
+	setWindowVisible("ReturnMenuButton", false)
+	setWindowVisible("RetryButton", false)
+end
+
 function showTaiFighterUI()
 	setWindowVisible("TaiFighterWindow", true)
 	setWindowVisible("PauseWindow", false)
@@ -51,4 +71,15 @@ function PlayCallback()
 
 	showTaiFighterUI()
 	Manager:changeScene('level1')
+end
+
+function ReturnMenuCallback()
+	hideDeathUI()
+	showMainMenuUI()
+	Manager:changeScene('MainMenuScene')
+end
+
+function RetryCallback()
+	hideDeathUI()
+	Manager:changeScene(Manager:getCurrentSceneName())
 end

--- a/TaiFighter/assets/scripts/Client/main.lua
+++ b/TaiFighter/assets/scripts/Client/main.lua
@@ -28,6 +28,7 @@ setButtonFunction("PlayButton","PlayCallback")
 
 -- showTaiFighterUI()
 -- showPauseUI()
+createDeathUI()
 showMainMenuUI()
 
 LOG("main.lua completed")


### PR DESCRIPTION
Necesita [Pull de PTSD](https://github.com/PTSD-3D/PTSD-Engine/pull/82).

Cuando te quedas sin vidas (poned el prefab con 1 de vida para probarlo de forma sencilla)

- Te salta una UI que te permite volver al menu principal o reintentar el nivel
- Se para tanto tu movimiento como el de tus enemigos